### PR TITLE
fixed end of level to stop user from playing

### DIFF
--- a/Isle of Trust/src/routes/TutorialGameView.tsx
+++ b/Isle of Trust/src/routes/TutorialGameView.tsx
@@ -617,7 +617,7 @@ class TutorialView extends React.Component<StartInfo, GameViewState> {
         if (
             this.props.level >= 1 &&
             this.props.level <= 6 &&
-            this.state.turnCount === 10
+            this.state.turnCount >= 10
         ) {
         // Check to make sure users can pay mortgage
         let payMortgage = 0;


### PR DESCRIPTION
Easy fix. I didn't think about player playing quickly and not waiting a few seconds after each round didn't have a cap feature it only looked for round 10 after 5 seconds but player would move past that round before time period missing the logic. 